### PR TITLE
Add monthly installs KPI and search filter

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -546,6 +546,14 @@ def filter_data(df, filters):
             (df.get('Job_Creation', pd.NaT) <= end_date)
         )
 
+    # Text search filter
+    if filters.get('search_query'):
+        query = str(filters['search_query']).strip().lower()
+        if query:
+            name_match = df.get('Job_Name', '').str.lower().str.contains(query, na=False)
+            po_match = df.get('Production_', '').astype(str).str.contains(query, na=False)
+            mask &= name_match | po_match
+
     return df[mask]
 
 def export_data_summary(df, filename_prefix="floform_data"):

--- a/visualization.py
+++ b/visualization.py
@@ -375,7 +375,40 @@ def create_revenue_trend_chart(df):
     
     # Format y-axis as currency
     fig.update_yaxes(tickformat='$,.0f')
-    
+
+    return fig
+
+
+def create_monthly_installs_trend(df, today):
+    """Create line chart showing installs for the current month."""
+
+    if df.empty or 'Install_Date' not in df.columns:
+        return None
+
+    start_of_month = pd.Timestamp(today.year, today.month, 1)
+    month_df = df[(df['Install_Date'].notna()) &
+                  (df['Install_Date'] >= start_of_month) &
+                  (df['Install_Date'] <= today)]
+
+    if month_df.empty:
+        return None
+
+    daily_installs = (month_df
+                      .groupby(month_df['Install_Date'].dt.date)
+                      .size()
+                      .reset_index(name='Installs'))
+
+    fig = px.line(
+        daily_installs,
+        x='Install_Date',
+        y='Installs',
+        title='Daily Installs This Month',
+        markers=True,
+        labels={'Install_Date': 'Date', 'Installs': 'Number of Installs'}
+    )
+
+    fig.update_layout(height=250, margin=dict(l=20, r=20, t=40, b=20))
+
     return fig
 
 def create_profitability_scatter(df):


### PR DESCRIPTION
## Summary
- Display installs this month with a KPI card and trend chart
- Support searching jobs by name or PO number in operational filters
- Provide chart helper to plot daily installs for current month

## Testing
- `python -m py_compile ui_components.py visualization.py data_processing.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0c84709b4832c8f34d40dd9a127f1