### PR TITLE
Handle division column variations in direct pricing analysis

### DIFF
--- a/pricing_analysis_ui.py
+++ b/pricing_analysis_ui.py
@@ -46,8 +46,9 @@ def analyze_interbranch_pricing_direct(df):
     
     # Filter for jobs that should have interbranch costs (Stone/Quartz with plant costs)
     try:
+        division_col = 'Division_Type' if 'Division_Type' in df_work.columns else 'Division'
         candidates = df_work[
-            (df_work.get('Division_Type', '') == 'Stone/Quartz') &
+            (df_work[division_col] == 'Stone/Quartz') &
             (df_work['Job_Material'].notna()) &
             (df_work['Total_Job_SqFT'].notna()) &
             (df_work['Total_Job_SqFT'] > 0) &
@@ -59,13 +60,14 @@ def analyze_interbranch_pricing_direct(df):
     except Exception as e:
         st.error(f"Error filtering data: {e}")
         st.info("Attempting alternative filtering method...")
-        
+
         # Alternative filtering with more robust checks
         mask = pd.Series([True] * len(df_work))
-        
+
         # Division check
-        if 'Division_Type' in df_work.columns:
-            mask &= (df_work['Division_Type'] == 'Stone/Quartz')
+        division_col = 'Division_Type' if 'Division_Type' in df_work.columns else 'Division'
+        if division_col in df_work.columns:
+            mask &= (df_work[division_col] == 'Stone/Quartz')
         
         # Material check
         if 'Job_Material' in df_work.columns:


### PR DESCRIPTION
## Summary
- handle both `Division_Type` and `Division` columns when filtering interbranch pricing candidates
- apply same division selection in fallback mask to avoid missing Stone/Quartz jobs

## Testing
- `python -m pytest`
- `python - <<'PY'
import pandas as pd
from pricing_analysis_ui import analyze_interbranch_pricing_direct

df = pd.DataFrame([
    {'Division': 'Stone/Quartz', 'Job_Material': 'random', 'Total_Job_SqFT': 10, 'Total_Job_Price_': 1000, 'Phase_Dollars_Plant_Invoice_': 200, 'Job_Type': 'Retail'},
    {'Division': 'Laminate', 'Job_Material': 'random', 'Total_Job_SqFT': 12, 'Total_Job_Price_': 1200, 'Phase_Dollars_Plant_Invoice_': 220, 'Job_Type': 'Retail'},
    {'Division': 'Other', 'Job_Material': 'random', 'Total_Job_SqFT': 15, 'Total_Job_Price_': 1500, 'Phase_Dollars_Plant_Invoice_': 300, 'Job_Type': 'Retail'}
])

results = analyze_interbranch_pricing_direct(df)
print('Candidate count:', len(results))
print('Divisions returned:', [r.get('Division') for r in results])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a4d9c2dfe4832c9604a5b342a1bcf8