### PR TITLE
Handle missing Google Sheets secrets

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -402,7 +402,17 @@ def load_raw_data():
             "https://www.googleapis.com/auth/spreadsheets",
             "https://www.googleapis.com/auth/drive"
         ]
-        
+
+        # Ensure credentials are available in Streamlit secrets
+        if "gsheets" not in st.secrets:
+            st.error("Google Sheets credentials not configured.")
+            st.info(
+                "Add a [gsheets] section to your Streamlit secrets. "
+                "See https://docs.streamlit.io/streamlit-community-cloud/deploy-your-app/secrets-management "
+                "for more information."
+            )
+            return pd.DataFrame()
+
         # Get credentials from Streamlit secrets
         credentials_dict = dict(st.secrets["gsheets"])
         credentials = Credentials.from_service_account_info(credentials_dict, scopes=scopes)


### PR DESCRIPTION
## Summary
- Add explicit check for Google Sheets credentials in Streamlit secrets
- Provide user guidance when gsheets configuration is missing before attempting to connect

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4f71c3fbc832c8c34c8d2590143d0